### PR TITLE
clarifies long and shorthands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ value length.
     USER=d...
     ```
 
-- Set `-maskMethod` to `random` to replace the environment variable value with 
+- Set `-maskMethod` or `-m` to `random` to replace the environment variable value with 
 random characters.
 
     ```
@@ -55,7 +55,7 @@ random characters.
     USER=me8
     ```
 
-- Set `-maskMethod` to a value that is neither `trunc` nor `random` to replace 
+- Set `-maskMethod` or `-m` to a value that is neither `trunc` nor `random` to replace 
 the environment variable value with the provided value.
 
     ```
@@ -68,7 +68,7 @@ the environment variable value with the provided value.
     USER=000
     ```
 
-- Set `-truncate` to a length to truncate the environment variable value. If the
+- Set `-truncLength` or `-t` to a length to truncate the environment variable value. If the
 specified length is greater than or equal to the length of the value, `envo` 
 will truncate the value to a third of its original length.
 


### PR DESCRIPTION
Hello @im2nguyen,

This PR clarifies some things in the README. Lines 50 and 58 are optional. Line 71 refers to `-truncate` which I believe should be `-truncLength `